### PR TITLE
Update project config to use `pin`

### DIFF
--- a/renovate-project.json5
+++ b/renovate-project.json5
@@ -1,8 +1,8 @@
 {
   // Renovate preset for Resonant projects (applications, Python/uv and npm).
   //
-  // Projects use tight version specifiers for reproducibility. Renovate bumps
-  // them to latest and handles lock file maintenance for transitive updates.
+  // Projects use exact pins for reproducibility. Renovate pins all deps to
+  // ==X.Y.Z and handles lock file maintenance for transitive updates.
   //
   // Usage in your repo's .github/renovate.json5:
   //   { "extends": ["github>kitware-resonant/.github:renovate-project.json5"] }
@@ -11,19 +11,19 @@
     "github>kitware-resonant/.github:renovate-base.json5",
   ],
 
-  // "bump" raises lower bounds of ranges and updates exact pins to latest.
-  // Python: ==5.2.3 -> ==5.2.9, >=7 -> >=7.1.2, >=4.2,<5 -> >=4.2.28,<5
-  // npm: ^1.0.0 -> ^1.2.0, ~1.3.0 -> ~1.3.5 (range type preserved)
   // Projects review lock maintenance PRs manually, so run monthly to reduce noise.
   "lockFileMaintenance": {
     "schedule": ["before 4am on the first day of the month"],
   },
 
-  "rangeStrategy": "bump",
+  // "pin" converts any range to an exact version (e.g., >=0 -> ==5.2.9,
+  // >=4.2,<5 -> ==4.2.28, ^1.0.0 -> 1.2.0). This enforces == pins and
+  // enables >=0 placeholders in project templates.
+  "rangeStrategy": "pin",
 
   "packageRules": [
-    // IMPORTANT (Python only): "bump" will bump requires-python to the latest
-    // Python version (e.g., >=3.12 -> >=3.14.3), which breaks uv lock on
+    // IMPORTANT (Python only): "pin" will pin requires-python to the latest
+    // Python version (e.g., >=3.12 -> ==3.14.3), which breaks uv lock on
     // Renovate's runner and produces a PR with no uv.lock update. Disable
     // requires-python updates via pep621; let the pyenv rule handle
     // .python-version separately. No equivalent issue exists for npm.


### PR DESCRIPTION
This will ensure that templated new projects are converted to true pins by Renovate.