### PR TITLE
Don't update `django-resonant-settings` with the `resonant-cookiecutter`

### DIFF
--- a/renovate-project.json5
+++ b/renovate-project.json5
@@ -27,15 +27,22 @@
       "matchManagers": ["pep621"],
       "enabled": false,
     },
-    // Group Resonant cookiecutter updates with django-resonant-settings.
-    // The copier manager extracts the cookiecutter as a git URL (the depName),
-    // not as "copier" (which is the manager name, not a package name).
+    // The Resonant cookiecutter MUST have its own branch. Copier refuses to
+    // run on a dirty working tree, so if it shares a branch with any other
+    // manager (pep621, npm, …), that manager's updateDependency phase will
+    // modify files before copier's artifact step runs, making the tree dirty
+    // and silently skipping the template refresh.
     {
-      "matchPackageNames": [
-        "django-resonant-settings",
-        "https://github.com/kitware-resonant/cookiecutter-resonant",
+      "matchPackageNames": ["https://github.com/kitware-resonant/cookiecutter-resonant"],
+      "groupName": "resonant-cookiecutter",
+      "minimumReleaseAge": "0 days",
+      "prBodyNotes": [
+        "**Remember:** also update `django-resonant-settings` in `pyproject.toml` to the matching version (`{{{newVersion}}}`).",
       ],
-      "groupName": "resonant",
+    },
+    // django-resonant-settings is a first-party package — trust it immediately.
+    {
+      "matchPackageNames": ["django-resonant-settings"],
       "minimumReleaseAge": "0 days",
     },
   ],


### PR DESCRIPTION
This isn't ideal, but Copier won't run on a dirty working tree.