### PR TITLE
Don't require a stability cooldown for Copier updates

### DIFF
--- a/renovate-base.json5
+++ b/renovate-base.json5
@@ -133,10 +133,15 @@
     // https://github.com/renovatebot/renovate/issues/41652
     {
       "matchUpdateTypes": ["lockFileMaintenance", "replacement", "pin"],
+      // null instead of "0 days" to skip the check entirely
       "minimumReleaseAge": null,
       "prBodyNotes": [
         "⚠️ Minimum release age is not validated for this update type.",
       ],
+    },
+    {
+      "matchManagers": ["copier"],
+      "minimumReleaseAge": null,
     },
     // Pin until Celery is compatible with RabbitMQ 4.3.
     {

--- a/renovate-project.json5
+++ b/renovate-project.json5
@@ -41,7 +41,6 @@
     {
       "matchPackageNames": ["https://github.com/kitware-resonant/cookiecutter-resonant"],
       "groupName": "resonant-cookiecutter",
-      "minimumReleaseAge": "0 days",
       "prBodyNotes": [
         "**Remember:** also update `django-resonant-settings` in `pyproject.toml` to the matching version (`{{{newVersion}}}`).",
       ],


### PR DESCRIPTION
Metadata for this isn't available.